### PR TITLE
Fix 404 errors for /blog/**/* URLs in production build

### DIFF
--- a/Parkfile
+++ b/Parkfile
@@ -12,13 +12,21 @@ Parklife.application.routes do
   root crawl: true
 
   get "/index.xml"
+  get "/feed.xml"
+  get "/ja/feed.xml"
   get "/sitemap.xml"
   get "/robots.txt"
 
   get "/404.html"
 
   # Generate redirect pages for old URLs
+  get "/blog"
+
   Post.all.each do |post|
+    year = post.published_at.strftime("%Y")
+    month = post.published_at.strftime("%m")
+
     get "/blog/#{post.slug}"
+    get "/blog/#{year}/#{month}/#{post.slug}"
   end
 end


### PR DESCRIPTION
Add missing redirect routes for /blog/:year/:month/:slug format and feed URLs to Parkfile. These redirects ensure that legacy blog URLs properly redirect to the new Japanese blog paths.

🤖 Generated with [Claude Code](https://claude.ai/code)