### PR TITLE
Improve local switch callback by using I18n.with_locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,19 +2,12 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
-  before_action :set_locale
+  around_action :switch_locale
 
   private
 
-  def set_locale
-    I18n.locale = params[:locale] || (request.path.start_with?("/ja") ? :ja : :en)
-  end
-
-  def default_url_options
-    if I18n.locale == :ja
-      { locale: :ja }
-    else
-      {}
-    end
+  def switch_locale(&action)
+    locale = params[:locale] || I18n.default_locale
+    I18n.with_locale(locale, &action)
   end
 end


### PR DESCRIPTION
Improve local switch callback by using I18n.with_locale

According to Railds Guides:

> I18n.locale can leak into subsequent requests served by the same
> thread/process if it is not consistently set in every controller. For
> example executing I18n.locale = :es in one POST requests will have
> effects for all later requests to controllers that don't set the locale,
> but only in that particular thread/process. For that reason, instead of
> I18n.locale = you can use I18n.with_locale which does not have this leak
> issue.

https://guides.rubyonrails.org/i18n.html