### PR TITLE
Remove allow_browser versions: :modern

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,4 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
-
   around_action :switch_locale
 
   private


### PR DESCRIPTION
So we can use Chrome developer tools emulated browsers